### PR TITLE
增加获取终端窗口大小、终端窗口最大化、终端窗口恢复最大化前的大小、设置终端窗口在桌面的位置 函数

### DIFF
--- a/src/vt100.h
+++ b/src/vt100.h
@@ -61,7 +61,13 @@ void vt_show_cursor(void);
 void vt_store_screen(void);
 void vt_restore_screen(void);
 
-void vt_set_screen_size(rt_uint8_t col, rt_uint8_t row);
+void vt_set_terminal_size(rt_uint16_t col, rt_uint16_t row);
+void vt_set_terminal_position(rt_uint16_t col_px, rt_uint16_t row_px);
+#ifdef RT_USING_POSIX
+void vt_get_terminal_size(rt_uint16_t *col, rt_uint16_t *row);
+#endif /* RT_USING_POSIX */
+void vt_maximize_terminal(void);
+void vt_unmaximize_terminal(void);
 
 void vt_move_up(rt_uint16_t step);
 void vt_move_down(rt_uint16_t step);


### PR DESCRIPTION
vt_set_terminal_size 设置终端窗口大小 
vt_set_terminal_position 设置终端窗口在桌面的位置
vt_get_terminal_size 获取当前终端窗口的大小
vt_maximize_terminal 终端窗口最大化
vt_unmaximize_terminal 恢复终端窗口最大化前的大小